### PR TITLE
Use gender-neutral reminders

### DIFF
--- a/scripts/standup.js
+++ b/scripts/standup.js
@@ -26,7 +26,7 @@ module.exports = function(robot) {
     // Constants.
     var STANDUP_MESSAGES = [
         "Standup time!",
-        "Time for standup, you guys.",
+        "Time for standup, y'all.",
         "It's standup time once again!",
         "Get up, stand up (it's time for our standup)",
         "Standup time. Get up, humans",


### PR DESCRIPTION
Not all people at standups are "guys".

I chose "y'all" 'cause I'm partial to it, but there are a bunch of other good choices -- "folks" is nice and informal, too, and has a similar tone to "guys" without the gender implications.