### PR TITLE
Provide a better way to read the room from the message for slack and other adapters

### DIFF
--- a/scripts/standup.js
+++ b/scripts/standup.js
@@ -97,6 +97,15 @@ module.exports = function(robot) {
         robot.messageRoom(room, message);
     }
 
+    // Finds the room for most adaptors
+    function findRoom(msg) {
+        var room = msg.envelope.room;
+        if(room == undefined) {
+            room = msg.envelope.user.reply_to;
+        }
+        return room;
+    }
+
     // Stores a standup in the brain.
     function saveStandup(room, time) {
         var standups = getStandups();
@@ -146,23 +155,13 @@ module.exports = function(robot) {
     }
 
     robot.respond(/delete all standups/i, function(msg) {
-        if(robot.adapterName == 'slack') {
-            var room = msg.envelope.user.room;
-        } else {
-            var room = msg.envelope.user.reply_to;
-        }
-        var standupsCleared = clearAllStandupsForRoom(room);
+        var standupsCleared = clearAllStandupsForRoom(findRoom(msg));
         msg.send('Deleted ' + standupsCleared + ' standup' + (standupsCleared === 1 ? '' : 's') + '. No more standups for you.');
     });
 
     robot.respond(/delete ([0-5]?[0-9]:[0-5]?[0-9]) standup/i, function(msg) {
         var time = msg.match[1]
-        if(robot.adapterName == 'slack') {
-            var room = msg.envelope.user.room;
-        } else {
-            var room = msg.envelope.user.reply_to;
-        }
-        var standupsCleared = clearSpecificStandupForRoom(room, time);
+        var standupsCleared = clearSpecificStandupForRoom(findRoom(msg), time);
         if (standupsCleared === 0) {
             msg.send("Nice try. You don't even have a standup at " + time);
         }
@@ -174,26 +173,14 @@ module.exports = function(robot) {
     robot.respond(/create standup ([0-5]?[0-9]:[0-5]?[0-9])$/i, function(msg) {
         var time = msg.match[1];
 
-        // NOTE: This works for Hipchat. You may need to change this line to 
-        // match your adapter. 'room' must be saved in a format that will
-        // work with the robot.messageRoom function.
-        if(robot.adapterName == 'slack') {
-            var room = msg.envelope.user.room;
-        } else {
-            var room = msg.envelope.user.reply_to;
-        }
+        var room = findRoom(msg);
 
         saveStandup(room, time);
         msg.send("Ok, from now on I'll remind this room to do a standup every weekday at " + time);
     });
 
     robot.respond(/list standups$/i, function(msg) {
-        if(robot.adapterName == 'slack') {
-            var room = msg.envelope.user.room;
-        } else {
-            var room = msg.envelope.user.reply_to;
-        }
-        var standups = getStandupsForRoom(room);
+        var standups = getStandupsForRoom(findRoom(msg));
 
         if (standups.length === 0) {
             msg.send("Well this is awkward. You haven't got any standups set :-/");


### PR DESCRIPTION
With the new slack client, the room was always undefined.
Now, the room can be retrieved for slack and other adapters as well.