### PR TITLE
adding @here for hipchat notification purposes

### DIFF
--- a/scripts/standup.js
+++ b/scripts/standup.js
@@ -94,6 +94,9 @@ module.exports = function(robot) {
     // Fires the standup message.
     function doStandup(room) {
         var message = _.sample(STANDUP_MESSAGES);
+        if (robot.adapterName == "hipchat") {
+            message = "@here " + message;
+        }
         robot.messageRoom(room, message);
     }
 


### PR DESCRIPTION
This is the dumb implementation fix for #8 

If it's more sensible to use an env var and allow the admin to set an alert word, please see https://github.com/MattTheRat/hubot-standup-alarm/commit/719fbdd843690e49fe9d7f34b971dbe5198d5898