### PR TITLE
Add description to index to display commands when hubot help is called

### DIFF
--- a/index.coffee
+++ b/index.coffee
@@ -1,3 +1,20 @@
+# Description:
+#   Have Hubot remind you to do standups.
+#   hh:mm must be in the same timezone as the server Hubot is on. Probably UTC.
+#
+#   This is configured to work for Hipchat. You may need to change the 'create standup' command
+#   to match the adapter you're using.
+#
+# Dependencies:
+#   underscore
+#   cron
+#
+# Configuration:
+#   HUBOT_STANDUP_PREPEND
+#
+# Commands:
+#   hubot standup help
+
 Fs = require 'fs'
 Path = require 'path'
 


### PR DESCRIPTION
When you type `hubot help` it doesn't display any standup commands. I've added the normal standup help command to make it easier to find the modules commands for chat room users.