### PR TITLE
Adding ability to specify a standup day

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,15 @@ You can create as many standups as you like, across as many rooms as you like.
 
 `hubot create standup hh:mm UTC+2` - As above, with a shift to account for UTC offset
 
+`hubot create standup Monday@hh:mm` - Creates a standup at hh:mm (UTC) every Monday for this room
+
 `hubot list standups` - See all standups for this room
 
 `hubot list standups in every room` - See all standups in every room
 
 `hubot delete hh:mm standup` - If you have a standup at hh:mm, deletes it
+
+`hubot delete Monday@hh:mm standup` - If you have a standup on Monday at hh:mm, deletes it
 
 `hubot delete all standups` - Deletes all standups for this room.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hubot-standup-alarm",
-  "version": "0.0.6",
+  "version": "0.1.0",
   "description": "Hubot script to remind teams to do their standups.",
   "main": "index.js",
   "scripts": {},

--- a/scripts/standup.coffee
+++ b/scripts/standup.coffee
@@ -32,37 +32,43 @@ module.exports = (robot) ->
   # Compares current time to the time of the standup to see if it should be fired.
   standupShouldFire = (standup) ->
     standupTime = standup.time
+    standupDayOfWeek = standup.dayOfWeek
     utc = standup.utc
     now = new Date
+
     currentHours = undefined
     currentMinutes = undefined
     currentWeekday = undefined
     if utc
+      currentUTC = now.getUTC
       currentHours = now.getUTCHours() + parseInt(utc, 10)
       currentMinutes = now.getUTCMinutes()
-      currentMinutes = now.getUTCDay()
       if currentHours > 23
         currentHours -= 23
+      currentWeekday = now.getUTCDay()
     else
       currentHours = now.getHours()
       currentMinutes = now.getMinutes()
       currentWeekday = now.getDay()
+
     standupHours = standupTime.split(':')[0]
     standupMinutes = standupTime.split(':')[1]
-    standupDay = standupTime.split("@")[0]
     try
       standupHours = parseInt(standupHours, 10)
       standupMinutes = parseInt(standupMinutes, 10)
-      standupDay = getDayOfWeek(standupDay)
+      standupDayOfWeek = getDayOfWeek(standupDayOfWeek)
     catch _error
       return false
-    if standupHours == currentHours and standupMinutes == currentMinutes and standupDay and standupDay == currentWeekday
+
+    if standupHours == currentHours and standupMinutes == currentMinutes and (standupDayOfWeek == -1 or standupDayOfWeek == currentWeekday)
       return true
     false
 
   # Returns the number of a day of the week from a supplied string. Will only attempt to match the first 3 characters
   getDayOfWeek = (day) ->
-    days = ['sun', 'mon', 'tue', 'Wed', 'thu', 'fri', 'sat']
+    if (!day)
+      return -1;
+    days = ['sun', 'mon', 'tue', 'wed', 'thu', 'fri', 'sat']
     days.indexOf(day.toLowerCase().substring(0,3))
 
   # Returns all standups.
@@ -164,7 +170,12 @@ module.exports = (robot) ->
       msg.send 'Well this is awkward. You haven\'t got any standups set :-/'
     else
       standupsText = [ 'Here\'s your standups:' ].concat(_.map(standups, (standup) ->
-        'Time: ' + standup.time + (if standup.utc then ' UTC+'+ standup.utc else '') + ', Location: '+ standup.location
+        text =  'Time: ' + standup.time
+        if standup.utc
+          text += ' UTC+' + standup.utc
+        if standup.location
+          text +=', Location: '+ standup.location
+        text
       ))
       msg.send standupsText.join('\n')
     return
@@ -175,7 +186,12 @@ module.exports = (robot) ->
       msg.send 'No, because there aren\'t any.'
     else
       standupsText = [ 'Here\'s the standups for every room:' ].concat(_.map(standups, (standup) ->
-        'Room: ' + standup.room + ', Time: ' + standup.time + (if standup.utc then ' UTC+'+ standup.utc else '') + ', Location: '+ standup.location
+        text =  'Room: ' + standup.room + ', Time: ' + standup.time
+        if standup.utc
+          text += ' UTC+' + standup.utc
+        if standup.location
+          text +=', Location: '+ standup.location
+        text
       ))
       msg.send standupsText.join('\n')
     return


### PR DESCRIPTION
Where I work, we don't do daily standups. Instead we have a standup on a Monday & a standup on a Friday. So I wanted to alter the script to support this kind of functionality.

I've also made some additional changes though including:
- Trying to standardize the format of the commands more so that it roughly followed a pattern of `[action] standup(s) [time] [utcOffset] [location]`
- Locations didn't seem to be fully implemented so I tweaked those a bit.

It's WIP because the cron alters currently aren't working as I test locally but I wanted to get it up for review early. I've not written much CoffeeScript in my life so getting some eyes on it early means I can fix things quicker.