### PR TITLE
Adding an environment variable to allow customization of the work week

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,13 +17,15 @@ You can create as many standups as you like, across as many rooms as you like.
 
 `hubot create standup hh:mm` - Creates a standup at hh:mm (UTC) every weekday for this room
 
+`hubot create standup hh:mm by the water cooler` - Creates a standup at hh:mm (UTC) every weekday for this room, specifying a location ('by the water cooler')
+
 `hubot create standup hh:mm UTC+2` - As above, with a shift to account for UTC offset
 
 `hubot create standup Monday@hh:mm` - Creates a standup at hh:mm (UTC) every Monday for this room
 
 `hubot list standups` - See all standups for this room
 
-`hubot list standups in every room` - See all standups in every room
+`hubot list all standups` - See all standups in every room
 
 `hubot delete hh:mm standup` - If you have a standup at hh:mm, deletes it
 
@@ -34,6 +36,9 @@ You can create as many standups as you like, across as many rooms as you like.
 ## Environment Variables
 
 You can set ```HUBOT_STANDUP_PREPEND``` to define a string that will be prepended to the alert messages Hubot sends. Typically, you'd use this to trigger an alert to everybody, for example, *@here* will alert everybody active in a Hipchat room, and *@all* does the same for Flowdock.
+
+```HUBOT_STANDUP_WEEKDAYS``` allows you to customize the days the standup check fires on. It defaults to `1-5` (Monday-Friday). Setting this to
+`0-4` will check for standup Sunday-Thursday. The syntax is the day of week specifier in the Linux cron format.
 
 ## Local Time
 

--- a/scripts/standup.coffee
+++ b/scripts/standup.coffee
@@ -50,7 +50,6 @@ module.exports = (robot) ->
     if result then true else false
 
   # Returns the number of a day of the week from a supplied string. Will only attempt to match the first 3 characters
-  # Sat/Sun currently aren't supported by the cron but are included to ensure indexes are correct
   getDayOfWeek = (day) ->
     if (!day)
       return -1
@@ -196,8 +195,9 @@ module.exports = (robot) ->
     PREPEND_MESSAGE += ' '
 
   # Check for standups that need to be fired, once a minute
-  # Monday to Friday.
-  new cronJob('1 * * * * 1-5', checkStandups, null, true)
+  # Defaults to Monday to Friday.
+  WEEKDAYS_CRON = process.env.HUBOT_STANDUP_WEEKDAYS or '1-5'
+  new cronJob('1 * * * * '+ WEEKDAYS_CRON, checkStandups, null, true)
 
   # Global regex should match all possible options
   robot.respond /(.*)standups? ?(?:([A-z]*)\s?\@\s?)?((?:[01]?[0-9]|2[0-4]):[0-5]?[0-9])?(?: UTC([- +]\d\d?))?(.*)/i, (msg) ->


### PR DESCRIPTION
As mentioned in #19 excluding a day from the standup rotation, or changing what the work week is, can be a handy feature. The ability to change the cron for when to check for standups will achieve both of these.

The only thing I'm a little unhappy with is that it'll still say you're creating your standup on a "weekday", even if you change the cron to say Sat-Sun. Might change that to "workday" potentially? Any thoughts? Picky thing I know!