### PR TITLE
Make HUBOT_STANDUP_WEEKDAYS work

### DIFF
--- a/scripts/standup.coffee
+++ b/scripts/standup.coffee
@@ -211,8 +211,9 @@ module.exports = (robot) ->
     PREPEND_MESSAGE += ' '
 
   # Check for standups that need to be fired, once a minute
-  # Monday to Friday.
-  new cronJob('1 * * * * 1-5', checkStandups, null, true)
+  # Defaults to Monday to Friday.
+  WEEKDAYS_CRON = process.env.HUBOT_STANDUP_WEEKDAYS or '1-5'
+  new cronJob('1 * * * * '+ WEEKDAYS_CRON, checkStandups, null, true)
 
   # Global regex should match all possible options
   robot.respond /(.*?)standups? ?(?:([A-z]*)\s?\@\s?)?((?:[01]?[0-9]|2[0-4]):[0-5]?[0-9])?(?: UTC([- +]\d\d?))?(.*)/i, (msg) ->


### PR DESCRIPTION
Currently the option `HUBOT_STANDUP_WEEKDAYS` doesn't work. It looks like during the development of https://github.com/hubot-scripts/hubot-standup-alarm/pull/30 that @ltheobald may have accidentally removed the lines that made it work in https://github.com/hubot-scripts/hubot-standup-alarm/pull/30/commits/9937602b22657e0eb8a3a0f9443f323767244106#diff-7ff5edbc5c4865f6d686f7f403db2424L198

This PR adds those lines back in.